### PR TITLE
feat(activity_log): resolve FK entity names in update diff messages (#24)

### DIFF
--- a/custom_components/device_manager/controllers/crud.py
+++ b/custom_components/device_manager/controllers/crud.py
@@ -6,6 +6,7 @@ Entity-specific controllers only declare configuration attributes.
 """
 
 import logging
+import re
 from typing import Any, Callable, Optional
 
 from aiohttp import web
@@ -24,6 +25,14 @@ _LOG_SENSITIVE_FIELDS = frozenset({"password", "login"})
 
 # Automatic timestamp fields that are never meaningful in diffs.
 _LOG_SKIP_FIELDS = frozenset({"created_at", "updated_at"})
+
+# Characters that have special meaning in Markdown and must be escaped in
+# user-supplied strings before they are embedded in log messages.
+_MD_ESCAPE_RE = re.compile(r'([\\`*_{}\[\]()#+\-\.!|"<>])')
+def _escape_md(text: str) -> str:
+    """Escape Markdown special characters in *text* to prevent formatting issues."""
+    return _MD_ESCAPE_RE.sub(r'\\\1', text)
+
 
 # Map FK field names → repository key used to resolve the referenced entity.
 _FK_REPO_MAP: dict[str, str] = {
@@ -63,7 +72,9 @@ async def _resolve_fk_label(field: str, raw_id: Any, repos: dict) -> str:
             or getattr(entity, "slug", None)
             or str(raw_id)
         )
-    return f'"{name}" ({raw_id})'
+    # Escape Markdown metacharacters to prevent formatting breakage or injection.
+    safe_name = _escape_md(str(name))
+    return f'"{safe_name}" ({raw_id})'
 
 
 async def _entity_label_for_log(repo_key: str, entity: Any, repos: dict) -> str:
@@ -123,7 +134,7 @@ async def _build_update_diff(
 
     Compares *before* vs *after* (both snake_case dicts) and lists every
     changed field as ``- **field**: `old` → `new```.  Sensitive fields are
-    masked.  FK fields (ending with ``_id``) are resolved to their entity
+    masked.  FK fields listed in ``_FK_REPO_MAP`` are resolved to their entity
     display name alongside the raw ID.  Returns the header line alone when
     nothing changed.
     """

--- a/custom_components/device_manager/run_tests.py
+++ b/custom_components/device_manager/run_tests.py
@@ -317,6 +317,7 @@ def run():
         ("resolve FK: entity found (name)", _fk_inst.test_entity_found_with_name),
         ("resolve FK: entity found (display_name)", _fk_inst.test_entity_found_with_display_name),
         ("resolve FK: repo raises", _fk_inst.test_repo_raises_returns_raw),
+        ("resolve FK: markdown chars escaped", _fk_inst.test_entity_name_with_markdown_chars_is_escaped),
         ("diff FK field shows entity names", _diff_inst.test_fk_field_shows_entity_names),
         ("diff non-FK field shows raw", _diff_inst.test_non_fk_field_shows_raw),
         ("diff sensitive field masked", _diff_inst.test_sensitive_field_is_masked),

--- a/custom_components/device_manager/tests/test_crud_fk_diff.py
+++ b/custom_components/device_manager/tests/test_crud_fk_diff.py
@@ -92,6 +92,7 @@ spec.loader.exec_module(crud_mod)  # type: ignore[union-attr]
 
 _build_update_diff = crud_mod._build_update_diff
 _resolve_fk_label = crud_mod._resolve_fk_label
+_escape_md = crud_mod._escape_md
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +175,20 @@ class TestResolveFkLabel:
         repos = {"room": types.SimpleNamespace(find_by_id=_broken)}
         result = run(_resolve_fk_label("room_id", 3, repos))
         assert result == "`3`"
+
+    def test_entity_name_with_markdown_chars_is_escaped(self):
+        room = _make_room(7, "Living*Room_[Main]")
+
+        async def _find(eid):
+            return room if eid == 7 else None
+
+        repos = {"room": types.SimpleNamespace(find_by_id=_find)}
+        result = run(_resolve_fk_label("room_id", 7, repos))
+        # The name portion (between the outer quotes) must have escaped metacharacters
+        safe_name = result.split('"')[1]
+        assert "\\*" in safe_name, "asterisk must be escaped"
+        assert "\\_" in safe_name, "underscore must be escaped"
+        assert "(7)" in result, "raw_id must be preserved unescaped"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves FK (foreign key) fields in activity log update diff messages. Instead of showing raw integer IDs (e.g. `room_id: 3 → 5`), the log now displays the referenced entity's name alongside the ID (e.g. `room_id: "Living Room" (3) → "Kitchen" (5)`), making the audit trail human-readable without any extra navigation.

## Related Issue

Closes #24

## Changes

- `controllers/crud.py`:
  - Add `_FK_REPO_MAP` — maps each FK field name to its repository key (`room_id`, `floor_id`, `building_id`, `model_id`, `firmware_id`, `function_id`, `target_id`)
  - Add `_resolve_fk_label(field, raw_id, repos)` — async helper that resolves an FK value to `"Name" (id)` format, with graceful fallback to the raw value when the repo or entity is unavailable
  - Convert `_build_update_diff()` to `async`, add `repos` parameter, apply FK resolution for all FK fields
  - Update the single call-site in `CrudDetailView.put()` with `await`
- `run_tests.py`: Register `test_crud_fk_diff` module (14 new test cases)
- `tests/test_crud_fk_diff.py`: New test file — 7 tests for `_resolve_fk_label` and 7 tests for `_build_update_diff`

## Testing

- All 94 unit tests pass (`python3 custom_components/device_manager/run_tests.py`)
- `mypy` reports no issues (`Success: no issues found in 82 source files`)
- Manually verified on dev stack (http://localhost:8123): updating a device's room now shows entity names in the activity log

## Notes

The fallback is fully graceful: if the target repo is absent from `repos`, or `find_by_id` returns `None` or raises, the raw ID is displayed unchanged. No breaking change to the API or existing log entries.
