### PR TITLE
improve(tests): harmonize unit test structure (shared helpers, TEST_SUITE pattern) (#39)

### DIFF
--- a/custom_components/device_manager/run_tests.py
+++ b/custom_components/device_manager/run_tests.py
@@ -11,10 +11,15 @@ import sys
 from pathlib import Path
 import importlib.util
 
+# Expose tests/ so test modules can do: import helpers
+_tests_dir = Path(__file__).resolve().parent / "tests"
+if str(_tests_dir) not in sys.path:
+    sys.path.insert(0, str(_tests_dir))
 
-def load_test_module(module_name: str):
+
+def _load_test_module(module_name: str):
     """Load a test module by file path to avoid package imports."""
-    test_path = Path(__file__).resolve().parent / 'tests' / f'{module_name}.py'
+    test_path = _tests_dir / f"{module_name}.py"
     spec = importlib.util.spec_from_file_location(module_name, str(test_path))
     assert spec is not None, f"Cannot find spec for {module_name}"
     module = importlib.util.module_from_spec(spec)
@@ -23,70 +28,22 @@ def load_test_module(module_name: str):
     return module
 
 
-# Load test modules
-test_device = load_test_module('test_device')
-test_import = load_test_module('test_import')
-test_dm_device_computed = load_test_module('test_dm_device_computed')
-test_identifier_validation = load_test_module('test_identifier_validation')
-test_ha_groups = load_test_module('test_ha_groups')
-test_ha_floors = load_test_module('test_ha_floors')
-test_ha_rooms = load_test_module('test_ha_rooms')
-test_crud_fk_diff = load_test_module('test_crud_fk_diff')
-test_mosquitto_config = load_test_module('test_mosquitto_config')
-test_init_unload = load_test_module('test_init_unload')
-test_network_scanner = load_test_module('test_network_scanner')
-
-# Import test functions from test_device
-test_compute_derived_fields_from_fixtures = (
-    test_device.test_compute_derived_fields_from_fixtures
-)
-
-# Import test functions from test_import
-test_csv_import_to_db = test_import.test_csv_import_to_db
-
-# Import test functions from test_dm_device_computed
-test_mqtt_topic_format = (
-    test_dm_device_computed.test_mqtt_topic_format
-)
-test_mqtt_topic_returns_none_when_missing_building = (
-    test_dm_device_computed.test_mqtt_topic_returns_none_when_missing_building
-)
-test_mqtt_topic_structure = (
-    test_dm_device_computed.test_mqtt_topic_structure
-)
-test_hostname_format = test_dm_device_computed.test_hostname_format
-test_hostname_returns_none_when_missing_building = (
-    test_dm_device_computed.test_hostname_returns_none_when_missing_building
-)
-test_fqdn_format = test_dm_device_computed.test_fqdn_format
-test_fqdn_custom_suffix = test_dm_device_computed.test_fqdn_custom_suffix
-test_display_name_full = test_dm_device_computed.test_display_name_full
-test_display_name_fallback_to_mac = (
-    test_dm_device_computed.test_display_name_fallback_to_mac
-)
-test_link_with_full_ip = test_dm_device_computed.test_link_with_full_ip
-test_link_with_numeric_ip = test_dm_device_computed.test_link_with_numeric_ip
-test_to_camel_dict_full_includes_computed = (
-    test_dm_device_computed.test_to_camel_dict_full_includes_computed
-)
-
-# Import test functions from test_identifier_validation
-test_mac_colon_uppercase = test_identifier_validation.test_mac_colon_uppercase
-test_mac_colon_lowercase = test_identifier_validation.test_mac_colon_lowercase
-test_mac_hyphen = test_identifier_validation.test_mac_hyphen
-test_mac_compact = test_identifier_validation.test_mac_compact
-test_eui64_colon = test_identifier_validation.test_eui64_colon
-test_zigbee_eui64_hex_prefix = test_identifier_validation.test_zigbee_eui64_hex_prefix
-test_empty_string_rejected = test_identifier_validation.test_empty_string_rejected
-test_plain_text_rejected = test_identifier_validation.test_plain_text_rejected
-test_non_hex_chars_rejected = test_identifier_validation.test_non_hex_chars_rejected
-test_ip_address_rejected = test_identifier_validation.test_ip_address_rejected
-test_short_mac_rejected = test_identifier_validation.test_short_mac_rejected
-test_short_eui64_rejected = test_identifier_validation.test_short_eui64_rejected
-test_eui64_wrong_prefix_rejected = test_identifier_validation.test_eui64_wrong_prefix_rejected
+_TEST_MODULES = [
+    "test_device",
+    "test_import",
+    "test_dm_device_computed",
+    "test_identifier_validation",
+    "test_ha_groups",
+    "test_ha_floors",
+    "test_ha_rooms",
+    "test_crud_fk_diff",
+    "test_mosquitto_config",
+    "test_init_unload",
+    "test_network_scanner",
+]
 
 
-def run():
+def run() -> None:
     """Run all tests and display results."""
     failures = 0
     total_tests = 0
@@ -95,347 +52,33 @@ def run():
     print(" HA Device Manager - Test Suite")
     print("=" * 70)
 
-    # Legacy DmDevice tests with fixtures
-    print("\n📦 Device Model Tests (Legacy Fixtures)")
-    device_tests = [
-        ("compute derived fields from fixtures", test_compute_derived_fields_from_fixtures),
-    ]
+    for module_name in _TEST_MODULES:
+        mod = _load_test_module(module_name)
+        suite_label: str = getattr(mod, "SUITE_LABEL", module_name)
+        suite: list = getattr(mod, "TEST_SUITE", [])
 
-    for test_name, test_func in device_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
+        print(f"\n{suite_label}")
+        for test_name, test_func in suite:
+            total_tests += 1
+            try:
+                test_func()
+                print(f"  ✓ {test_name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"  ✗ {test_name}")
+                print(f"    {e}")
+            except Exception as e:
+                failures += 1
+                print(f"  ✗ {test_name} (ERROR)")
+                print(f"    {type(e).__name__}: {e}")
 
-    # CSV Import tests
-    print("\n📥 CSV Import Tests")
-    import_tests = [
-        ("csv import to database", test_csv_import_to_db),
-    ]
-
-    for test_name, test_func in import_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # DmDevice computed methods tests
-    print("\n🔧 DmDevice Computed Methods Tests")
-    computed_tests = [
-        ("mqtt_topic format & lowercase", test_mqtt_topic_format),
-        ("mqtt_topic None when missing building", test_mqtt_topic_returns_none_when_missing_building),
-        ("mqtt_topic structure (5 segments)", test_mqtt_topic_structure),
-        ("hostname format & lowercase", test_hostname_format),
-        ("hostname None when missing building", test_hostname_returns_none_when_missing_building),
-        ("fqdn format & lowercase", test_fqdn_format),
-        ("fqdn custom suffix", test_fqdn_custom_suffix),
-        ("display_name full hierarchy", test_display_name_full),
-        ("display_name fallback to MAC", test_display_name_fallback_to_mac),
-        ("link with full IP", test_link_with_full_ip),
-        ("link with numeric IP", test_link_with_numeric_ip),
-        ("to_camel_dict_full includes computed fields", test_to_camel_dict_full_includes_computed),
-    ]
-
-    for test_name, test_func in computed_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # Identifier validation tests
-    print("\n🔒 Identifier Validation Tests")
-    identifier_tests = [
-        ("MAC colon uppercase", test_mac_colon_uppercase),
-        ("MAC colon lowercase", test_mac_colon_lowercase),
-        ("MAC hyphen", test_mac_hyphen),
-        ("MAC compact", test_mac_compact),
-        ("EUI-64 colon", test_eui64_colon),
-        ("Zigbee EUI-64 (0x...)", test_zigbee_eui64_hex_prefix),
-        ("empty string rejected", test_empty_string_rejected),
-        ("plain text rejected", test_plain_text_rejected),
-        ("non-hex chars rejected", test_non_hex_chars_rejected),
-        ("IP address rejected", test_ip_address_rejected),
-        ("short MAC rejected", test_short_mac_rejected),
-        ("short EUI-64 rejected", test_short_eui64_rejected),
-        ("EUI-64 without 0x rejected", test_eui64_wrong_prefix_rejected),
-    ]
-
-    for test_name, test_func in identifier_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # HA Groups tests
-    print("\n🏠 HA Groups Controller Tests")
-    ha_groups_tests = [
-        ("slugify basic", test_ha_groups.test_slugify_basic),
-        ("slugify spaces", test_ha_groups.test_slugify_spaces),
-        ("slugify special chars", test_ha_groups.test_slugify_special_chars),
-        ("slugify multiple separators", test_ha_groups.test_slugify_multiple_separators),
-        ("ha_domain light", test_ha_groups.test_ha_domain_light),
-        ("ha_domain shutter → cover", test_ha_groups.test_ha_domain_shutter),
-        ("ha_domain heater → climate", test_ha_groups.test_ha_domain_heater),
-        ("ha_domain tv → media_player", test_ha_groups.test_ha_domain_tv),
-        ("ha_domain button → binary_sensor", test_ha_groups.test_ha_domain_button),
-        ("ha_domain energy → sensor", test_ha_groups.test_ha_domain_energy),
-        ("ha_domain unknown → switch", test_ha_groups.test_ha_domain_unknown_defaults_to_switch),
-        ("ha_domain case insensitive", test_ha_groups.test_ha_domain_case_insensitive),
-        ("plural light", test_ha_groups.test_plural_light),
-        ("plural shutter", test_ha_groups.test_plural_shutter),
-        ("plural unknown appends s", test_ha_groups.test_plural_unknown_appends_s),
-        ("device entity_id standard", test_ha_groups.test_device_entity_id_standard),
-        ("device entity_id matches hostname pattern", test_ha_groups.test_device_entity_id_matches_hostname_pattern),
-        ("device entity_id uppercase building", test_ha_groups.test_device_entity_id_uppercase_building),
-        ("device entity_id empty position omitted", test_ha_groups.test_device_entity_id_empty_position_omitted),
-        ("room group entity_id", test_ha_groups.test_room_group_entity_id),
-        ("floor group entity_id", test_ha_groups.test_floor_group_entity_id),
-        ("building group entity_id", test_ha_groups.test_building_group_entity_id),
-        ("room group special chars", test_ha_groups.test_room_group_special_chars),
-        ("floor group has building prefix", test_ha_groups.test_floor_group_has_building_prefix),
-        ("building group has building prefix", test_ha_groups.test_building_group_has_building_prefix),
-    ]
-
-    for test_name, test_func in ha_groups_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # HA Floors tests
-    print("\n🏢 HA Floors Controller Tests")
-    ha_floors_tests = [
-        ("registry create auto-generates floor_id", test_ha_floors.test_registry_create_auto_generates_id),
-        ("registry get_floor_by_name found", test_ha_floors.test_registry_get_floor_by_name_found),
-        ("registry get_floor_by_name missing", test_ha_floors.test_registry_get_floor_by_name_missing),
-        ("rollback deletes created floors", test_ha_floors.test_rollback_deletes_created_floors),
-        ("rollback restores updated floors", test_ha_floors.test_rollback_restores_updated_floors),
-        ("rollback is reversed order", test_ha_floors.test_rollback_is_reversed_order),
-        ("rollback skips update without original", test_ha_floors.test_rollback_skips_update_without_original),
-        ("rollback tolerates registry error", test_ha_floors.test_rollback_tolerates_registry_error),
-        ("create entry floor_id is accessible", test_ha_floors.test_create_entry_floor_id_is_accessible),
-        ("ha name per building is unique", test_ha_floors.test_ha_name_per_building_is_unique),
-        ("level resets per building", test_ha_floors.test_level_resets_per_building),
-    ]
-
-    for test_name, test_func in ha_floors_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # HA Rooms tests
-    print("\n🚪 HA Rooms Controller Tests")
-    ha_rooms_tests = [
-        ("registry create auto-generates area id", test_ha_rooms.test_registry_create_auto_generates_id),
-        ("registry create with floor_id", test_ha_rooms.test_registry_create_with_floor_id),
-        ("registry get_area_by_name missing", test_ha_rooms.test_registry_get_area_by_name_missing),
-        ("rollback deletes created areas", test_ha_rooms.test_rollback_deletes_created_areas),
-        ("rollback restores updated areas", test_ha_rooms.test_rollback_restores_updated_areas),
-        ("rollback is reversed order", test_ha_rooms.test_rollback_is_reversed_order),
-        ("rollback skips update without original", test_ha_rooms.test_rollback_skips_update_without_original),
-        ("rollback multiple rooms reversed", test_ha_rooms.test_rollback_multiple_rooms_reversed),
-        ("compute_area_id basic", test_ha_rooms.test_compute_area_id_basic),
-        ("slugify fallback ascii", test_ha_rooms.test_slugify_fallback_ascii),
-        ("compute_area_id special chars", test_ha_rooms.test_compute_area_id_special_chars),
-        ("registry create then update name keeps id", test_ha_rooms.test_registry_create_then_update_name_keeps_id),
-        ("compute_area_id matches registry create id", test_ha_rooms.test_compute_area_id_matches_registry_create_id),
-        ("registry get_area by id found", test_ha_rooms.test_registry_get_area_by_id_found),
-        ("registry get_area missing", test_ha_rooms.test_registry_get_area_missing),
-        ("duplicate name detection", test_ha_rooms.test_duplicate_name_detection),
-        ("unique name not marked duplicate", test_ha_rooms.test_unique_name_not_marked_duplicate),
-    ]
-
-    for test_name, test_func in ha_rooms_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # CRUD FK diff tests
-    print("\n🔗 CRUD FK Diff Tests")
-    _fk_inst = test_crud_fk_diff.TestResolveFkLabel()
-    _diff_inst = test_crud_fk_diff.TestBuildUpdateDiffFk()
-    crud_fk_tests = [
-        ("resolve FK: None value", _fk_inst.test_none_value_returns_none_marker),
-        ("resolve FK: unknown field", _fk_inst.test_unknown_field_returns_raw),
-        ("resolve FK: repo missing", _fk_inst.test_repo_not_in_repos_returns_raw),
-        ("resolve FK: entity not found", _fk_inst.test_entity_not_found_returns_raw),
-        ("resolve FK: entity found (name)", _fk_inst.test_entity_found_with_name),
-        ("resolve FK: entity found (display_name)", _fk_inst.test_entity_found_with_display_name),
-        ("resolve FK: repo raises", _fk_inst.test_repo_raises_returns_raw),
-        ("resolve FK: markdown chars escaped", _fk_inst.test_entity_name_with_markdown_chars_is_escaped),
-        ("diff FK field shows entity names", _diff_inst.test_fk_field_shows_entity_names),
-        ("diff non-FK field shows raw", _diff_inst.test_non_fk_field_shows_raw),
-        ("diff sensitive field masked", _diff_inst.test_sensitive_field_is_masked),
-        ("diff no changes returns header", _diff_inst.test_no_changes_returns_header_only),
-        ("diff skip fields ignored", _diff_inst.test_skip_fields_ignored),
-        ("diff FK None to value", _diff_inst.test_fk_none_to_value),
-        ("diff FK fallback when repos empty", _diff_inst.test_fk_fallback_when_repos_empty),
-    ]
-
-    for test_name, test_func in crud_fk_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # Mosquitto config generation tests
-    print("\n📡 Mosquitto Config Generation Tests")
-    mosquitto_tests = [
-        ("passwd contains room credentials", test_mosquitto_config.test_passwd_contains_room_credentials),
-        ("passwd contains admin", test_mosquitto_config.test_passwd_contains_admin),
-        ("acl room topic format", test_mosquitto_config.test_acl_room_topic_format),
-        ("acl admin full access", test_mosquitto_config.test_acl_admin_full_access),
-        ("room without credentials skipped", test_mosquitto_config.test_room_without_credentials_skipped),
-        ("mosquitto.conf references correct paths", test_mosquitto_config.test_mosquitto_conf_references_correct_paths),
-        ("zip contains three files", test_mosquitto_config.test_zip_contains_three_files),
-        ("mqtt prefix leading slash stripped", test_mosquitto_config.test_mqtt_prefix_leading_slash_stripped),
-        ("empty hierarchy only admin", test_mosquitto_config.test_empty_hierarchy_only_admin),
-        ("no admin password skips admin entry", test_mosquitto_config.test_no_admin_password_skips_admin_entry),
-        ("room with None password skipped", test_mosquitto_config.test_room_with_none_password_skipped),
-    ]
-
-    for test_name, test_func in mosquitto_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # __init__.py unload tests
-    print("\n🔌 Integration Unload Tests")
-    _unload_inst = test_init_unload.TestAsyncUnloadEntry()
-    _unload_inst.setUp()
-    init_unload_tests = [
-        ("async_remove_panel called on unload", _unload_inst.test_async_remove_panel_called_on_unload),
-        ("db closed on unload", _unload_inst.test_db_closed_on_unload),
-        ("hass.data cleared on unload", _unload_inst.test_hass_data_cleared_on_unload),
-        ("unload returns True", _unload_inst.test_unload_returns_true),
-    ]
-
-    for test_name, test_func in init_unload_tests:
-        total_tests += 1
-        try:
-            _unload_inst.setUp()
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # Network scanner error propagation tests
-    print("\n📡 Network Scanner Error Propagation Tests")
-    scanner_tests = [
-        ("missing script config raises", test_network_scanner.test_missing_scan_script_raises),
-        ("timeout raises NetworkScanError", test_network_scanner.test_timeout_raises),
-        ("subprocess exception raises", test_network_scanner.test_subprocess_exception_raises),
-        ("nonzero exit code raises", test_network_scanner.test_nonzero_exit_raises),
-        ("invalid YAML output raises", test_network_scanner.test_invalid_yaml_raises),
-        ("non-dict output raises", test_network_scanner.test_non_dict_output_raises),
-        ("successful scan returns dict", test_network_scanner.test_successful_scan_returns_dict),
-        ("update_device_ips without scan returns error", test_network_scanner.test_update_device_ips_without_scan_returns_error),
-        ("update_device_ips with empty scan proceeds", test_network_scanner.test_update_device_ips_with_empty_scan_proceeds),
-    ]
-
-    for test_name, test_func in scanner_tests:
-        total_tests += 1
-        try:
-            test_func()
-            print(f'  ✓ {test_name}')
-        except AssertionError as e:
-            failures += 1
-            print(f'  ✗ {test_name}')
-            print(f'    {e}')
-        except Exception as e:
-            failures += 1
-            print(f'  ✗ {test_name} (ERROR)')
-            print(f'    {type(e).__name__}: {e}')
-
-    # Summary
     print("\n" + "=" * 70)
     if failures:
         print(f"❌ {failures}/{total_tests} test(s) failed")
         sys.exit(1)
-    print(f'✅ All {total_tests} tests passed')
+    print(f"✅ All {total_tests} tests passed")
     print("=" * 70 + "\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run()

--- a/custom_components/device_manager/tests/helpers.py
+++ b/custom_components/device_manager/tests/helpers.py
@@ -1,0 +1,164 @@
+"""Shared test utilities for the device_manager test suite.
+
+Provides lazy, idempotent stub injectors and a generic module loader
+so individual test files do not need to duplicate bootstrapping code.
+
+This module is stdlib-only — no pytest or external dependencies.
+"""
+
+import importlib.util
+import re
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+# Base directory: custom_components/device_manager/ (parent of tests/)
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+def stub_ha_modules() -> None:
+    """Inject minimal Home Assistant stubs into sys.modules (lazy, idempotent).
+
+    Sets up:
+      - homeassistant
+      - homeassistant.components
+      - homeassistant.components.http  (with HomeAssistantView = object)
+    """
+    ha_http = types.ModuleType("homeassistant.components.http")
+    ha_http.HomeAssistantView = object  # type: ignore[attr-defined]
+
+    for name, mod in [
+        ("homeassistant", types.ModuleType("homeassistant")),
+        ("homeassistant.components", types.ModuleType("homeassistant.components")),
+        ("homeassistant.components.http", ha_http),
+    ]:
+        sys.modules.setdefault(name, mod)  # type: ignore[arg-type]
+
+
+def stub_aiohttp() -> None:
+    """Inject minimal aiohttp stubs into sys.modules (lazy, idempotent).
+
+    Sets up:
+      - aiohttp
+      - aiohttp.web  (with Request = object, Response = object)
+    """
+    aiohttp_mod = types.ModuleType("aiohttp")
+    web_mod = types.ModuleType("aiohttp.web")
+    web_mod.Request = object  # type: ignore[attr-defined]
+    web_mod.Response = object  # type: ignore[attr-defined]
+    aiohttp_mod.web = web_mod  # type: ignore[attr-defined]
+    sys.modules.setdefault("aiohttp", aiohttp_mod)
+    sys.modules.setdefault("aiohttp.web", web_mod)
+
+
+def load_module(
+    rel_path: str,
+    package: "str | None" = None,
+    module_name: "str | None" = None,
+):
+    """Load a Python module from a path relative to BASE_DIR.
+
+    Args:
+        rel_path:    Path relative to BASE_DIR using forward slashes.
+                     Example: 'models/device.py'
+        package:     Value to set as __package__ on the loaded module.
+                     Required for modules that use relative imports.
+        module_name: Override the module name (defaults to filename stem).
+
+    Returns:
+        The loaded module object.
+    """
+    full_path = BASE_DIR / rel_path
+    name = module_name or full_path.stem
+    spec = importlib.util.spec_from_file_location(name, str(full_path))
+    assert spec is not None and spec.loader is not None, (
+        f"Cannot load module from {rel_path}"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    if package is not None:
+        mod.__package__ = package
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@contextmanager
+def assert_raises(expected_exc, match: str = ""):
+    """Stdlib-only replacement for pytest.raises with optional message match.
+
+    Args:
+        expected_exc: Exception class expected to be raised.
+        match:        Optional regex pattern that must appear in str(exc).
+    """
+    try:
+        yield
+    except expected_exc as exc:  # type: ignore[misc]
+        if match and not re.search(match, str(exc)):
+            raise AssertionError(
+                f"{expected_exc.__name__} raised but message {str(exc)!r} "
+                f"did not match pattern {match!r}"
+            ) from exc
+        return
+    except Exception as exc:
+        raise AssertionError(
+            f"Expected {expected_exc.__name__}, got {type(exc).__name__}: {exc}"
+        ) from exc
+    raise AssertionError(f"{expected_exc.__name__} was not raised")
+
+
+# ---------------------------------------------------------------------------
+# High-level domain helpers
+# ---------------------------------------------------------------------------
+
+_device_model_cache: "object | None" = None
+
+
+def load_device_model():
+    """Load DmDevice and related refs classes (lazy, idempotent).
+
+    Injects the minimal custom_components.* namespace and loads:
+      - utils/case_convert.py
+      - models/base.py
+      - models/device.py
+
+    Returns a SimpleNamespace with attributes:
+      DmDevice, DeviceRoomRef, DeviceFloorRef, DeviceBuildingRef, DeviceLinkedRefs
+
+    Calling this function multiple times returns the same cached object.
+    """
+    global _device_model_cache
+    if _device_model_cache is not None:
+        return _device_model_cache
+
+    case_convert = load_module("utils/case_convert.py")
+
+    _cm = types.ModuleType("custom_components")
+    _dm = types.ModuleType("custom_components.device_manager")
+    _utils = types.ModuleType("custom_components.device_manager.utils")
+    _utils.case_convert = case_convert  # type: ignore[attr-defined]
+
+    sys.modules.setdefault("custom_components", _cm)
+    sys.modules.setdefault("custom_components.device_manager", _dm)
+    sys.modules.setdefault("custom_components.device_manager.utils", _utils)
+    sys.modules.setdefault("custom_components.device_manager.utils.case_convert", case_convert)
+
+    base_mod = load_module(
+        "models/base.py",
+        package="custom_components.device_manager.models",
+    )
+    sys.modules["custom_components.device_manager.models.base"] = base_mod
+
+    device_mod = load_module(
+        "models/device.py",
+        package="custom_components.device_manager.models",
+    )
+
+    import types as _types
+    _device_model_cache = _types.SimpleNamespace(
+        DmDevice=device_mod.DmDevice,
+        DeviceRoomRef=device_mod.DeviceRoomRef,
+        DeviceFloorRef=device_mod.DeviceFloorRef,
+        DeviceBuildingRef=device_mod.DeviceBuildingRef,
+        DeviceLinkedRefs=device_mod.DeviceLinkedRefs,
+    )
+    return _device_model_cache

--- a/custom_components/device_manager/tests/test_crud_fk_diff.py
+++ b/custom_components/device_manager/tests/test_crud_fk_diff.py
@@ -6,41 +6,23 @@ are masked, and that graceful fallback works when a repo or entity is missing.
 """
 
 import asyncio
-import importlib.util
 import sys
 import types
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 # ---------------------------------------------------------------------------
 # Minimal stub setup — load only crud.py under test
 # ---------------------------------------------------------------------------
 
-base_dir = Path(__file__).resolve().parents[1]
-
-# Stub aiohttp
-aiohttp_module = types.ModuleType("aiohttp")
-web_module = types.ModuleType("aiohttp.web")
-web_module.Request = object  # type: ignore[attr-defined]
-web_module.Response = object  # type: ignore[attr-defined]
-aiohttp_module.web = web_module  # type: ignore[attr-defined]
-sys.modules.setdefault("aiohttp", aiohttp_module)
-sys.modules.setdefault("aiohttp.web", web_module)
-
-# Stub homeassistant
-for mod_name in [
-    "homeassistant",
-    "homeassistant.components",
-    "homeassistant.components.http",
-]:
-    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
-
-ha_http = sys.modules["homeassistant.components.http"]
-
+helpers.stub_ha_modules()
+helpers.stub_aiohttp()
 
 class _FakeHAView:
     requires_auth = True
 
 
+ha_http = sys.modules["homeassistant.components.http"]
 ha_http.HomeAssistantView = _FakeHAView  # type: ignore[attr-defined]
 
 # Stub custom_components packages
@@ -81,14 +63,11 @@ case_convert_stub.to_snake_case_dict = lambda d: d  # type: ignore[attr-defined]
 sys.modules["custom_components.device_manager.utils.case_convert"] = case_convert_stub
 
 # Load the actual crud module
-crud_path = base_dir / "controllers" / "crud.py"
-spec = importlib.util.spec_from_file_location(
-    "custom_components.device_manager.controllers.crud", str(crud_path)
+crud_mod = helpers.load_module(
+    "controllers/crud.py",
+    package="custom_components.device_manager.controllers",
+    module_name="custom_components.device_manager.controllers.crud",
 )
-assert spec is not None and spec.loader is not None
-crud_mod = importlib.util.module_from_spec(spec)
-crud_mod.__package__ = "custom_components.device_manager.controllers"
-spec.loader.exec_module(crud_mod)  # type: ignore[union-attr]
 
 _build_update_diff = crud_mod._build_update_diff
 _resolve_fk_label = crud_mod._resolve_fk_label
@@ -99,7 +78,7 @@ _escape_md = crud_mod._escape_md
 # Helpers
 # ---------------------------------------------------------------------------
 
-def run(coro):
+def _run(coro):
     """Run a coroutine synchronously."""
     return asyncio.run(coro)
 
@@ -119,140 +98,155 @@ def _make_device(entity_id: int, display: str):
     return entity
 
 
-# ---------------------------------------------------------------------------
-# Tests for _resolve_fk_label
-# ---------------------------------------------------------------------------
+def _make_test_repos():
+    """Create a repos dict with room A and room B for diff tests."""
+    room_a = _make_room(3, "Living Room")
+    room_b = _make_room(5, "Kitchen")
 
+    async def _find_room(eid):
+        return {3: room_a, 5: room_b}.get(eid)
 
-class TestResolveFkLabel:
-    """Unit tests for the _resolve_fk_label helper."""
-
-    def test_none_value_returns_none_marker(self):
-        result = run(_resolve_fk_label("room_id", None, {}))
-        assert result == "_(none)_"
-
-    def test_unknown_field_returns_raw(self):
-        result = run(_resolve_fk_label("custom_field_id", 7, {}))
-        assert result == "`7`"
-
-    def test_repo_not_in_repos_returns_raw(self):
-        # room_id is in FK_REPO_MAP but repos dict is empty
-        result = run(_resolve_fk_label("room_id", 3, {}))
-        assert result == "`3`"
-
-    def test_entity_not_found_returns_raw(self):
-        async def _not_found(eid):
-            return None
-
-        repos = {"room": types.SimpleNamespace(find_by_id=_not_found)}
-        result = run(_resolve_fk_label("room_id", 99, repos))
-        assert result == "`99`"
-
-    def test_entity_found_with_name(self):
-        room = _make_room(3, "Living Room")
-
-        async def _find(eid):
-            return room if eid == 3 else None
-
-        repos = {"room": types.SimpleNamespace(find_by_id=_find)}
-        result = run(_resolve_fk_label("room_id", 3, repos))
-        assert result == '"Living Room" (3)'
-
-    def test_entity_found_with_display_name(self):
-        device = _make_device(5, "Sonoff TH16")
-
-        async def _find(eid):
-            return device if eid == 5 else None
-
-        repos = {"device": types.SimpleNamespace(find_by_id=_find)}
-        result = run(_resolve_fk_label("target_id", 5, repos))
-        assert result == '"Sonoff TH16" (5)'
-
-    def test_repo_raises_returns_raw(self):
-        async def _broken(eid):
-            raise RuntimeError("DB error")
-
-        repos = {"room": types.SimpleNamespace(find_by_id=_broken)}
-        result = run(_resolve_fk_label("room_id", 3, repos))
-        assert result == "`3`"
-
-    def test_entity_name_with_markdown_chars_is_escaped(self):
-        room = _make_room(7, "Living*Room_[Main]")
-
-        async def _find(eid):
-            return room if eid == 7 else None
-
-        repos = {"room": types.SimpleNamespace(find_by_id=_find)}
-        result = run(_resolve_fk_label("room_id", 7, repos))
-        # The name portion (between the outer quotes) must have escaped metacharacters
-        safe_name = result.split('"')[1]
-        assert "\\*" in safe_name, "asterisk must be escaped"
-        assert "\\_" in safe_name, "underscore must be escaped"
-        assert "(7)" in result, "raw_id must be preserved unescaped"
+    return {"room": types.SimpleNamespace(find_by_id=_find_room)}
 
 
 # ---------------------------------------------------------------------------
-# Tests for _build_update_diff
+# Tests for _resolve_fk_label (plain functions)
 # ---------------------------------------------------------------------------
 
+def test_fk_none_value_returns_none_marker():
+    result = _run(_resolve_fk_label("room_id", None, {}))
+    assert result == "_(none)_"
 
-class TestBuildUpdateDiffFk:
-    """Tests that FK fields display entity names in the diff."""
+def test_fk_unknown_field_returns_raw():
+    result = _run(_resolve_fk_label("custom_field_id", 7, {}))
+    assert result == "`7`"
 
-    def _make_repos(self):
-        room_a = _make_room(3, "Living Room")
-        room_b = _make_room(5, "Kitchen")
+def test_fk_repo_not_in_repos_returns_raw():
+    result = _run(_resolve_fk_label("room_id", 3, {}))
+    assert result == "`3`"
 
-        async def _find_room(eid):
-            return {3: room_a, 5: room_b}.get(eid)
+def test_fk_entity_not_found_returns_raw():
+    async def _not_found(eid):
+        return None
 
-        return {"room": types.SimpleNamespace(find_by_id=_find_room)}
+    repos = {"room": types.SimpleNamespace(find_by_id=_not_found)}
+    result = _run(_resolve_fk_label("room_id", 99, repos))
+    assert result == "`99`"
 
-    def test_fk_field_shows_entity_names(self):
-        repos = self._make_repos()
-        result = run(_build_update_diff("Device - foo", {"room_id": 3}, {"room_id": 5}, repos))
-        assert '"Living Room" (3)' in result
-        assert '"Kitchen" (5)' in result
-        assert "room_id" in result
+def test_fk_entity_found_with_name():
+    room = _make_room(3, "Living Room")
 
-    def test_non_fk_field_shows_raw(self):
-        result = run(_build_update_diff("Room - bar", {"name": "old"}, {"name": "new"}, {}))
-        assert "`old`" in result
-        assert "`new`" in result
+    async def _find(eid):
+        return room if eid == 3 else None
 
-    def test_sensitive_field_is_masked(self):
-        result = run(_build_update_diff("Device - x", {"password": "abc"}, {"password": "xyz"}, {}))
-        assert "`***`" in result
-        assert "abc" not in result
-        assert "xyz" not in result
+    repos = {"room": types.SimpleNamespace(find_by_id=_find)}
+    result = _run(_resolve_fk_label("room_id", 3, repos))
+    assert result == '"Living Room" (3)'
 
-    def test_no_changes_returns_header_only(self):
-        result = run(_build_update_diff("Room - foo", {"name": "same"}, {"name": "same"}, {}))
-        assert result == "Updated Room - foo"
-        assert "\n" not in result
+def test_fk_entity_found_with_display_name():
+    device = _make_device(5, "Sonoff TH16")
 
-    def test_skip_fields_ignored(self):
-        result = run(_build_update_diff(
-            "Room - foo",
-            {"name": "a", "updated_at": "2024-01-01"},
-            {"name": "a", "updated_at": "2024-06-01"},
-            {},
-        ))
-        assert result == "Updated Room - foo"
+    async def _find(eid):
+        return device if eid == 5 else None
 
-    def test_fk_none_to_value(self):
-        room_b = _make_room(5, "Kitchen")
+    repos = {"device": types.SimpleNamespace(find_by_id=_find)}
+    result = _run(_resolve_fk_label("target_id", 5, repos))
+    assert result == '"Sonoff TH16" (5)'
 
-        async def _find_room(eid):
-            return room_b if eid == 5 else None
+def test_fk_repo_raises_returns_raw():
+    async def _broken(eid):
+        raise RuntimeError("DB error")
 
-        repos = {"room": types.SimpleNamespace(find_by_id=_find_room)}
-        result = run(_build_update_diff("Device - foo", {"room_id": None}, {"room_id": 5}, repos))
-        assert "_(none)_" in result
-        assert '"Kitchen" (5)' in result
+    repos = {"room": types.SimpleNamespace(find_by_id=_broken)}
+    result = _run(_resolve_fk_label("room_id", 3, repos))
+    assert result == "`3`"
 
-    def test_fk_fallback_when_repos_empty(self):
-        # FK field but no repos — must fallback gracefully
-        result = run(_build_update_diff("Device - foo", {"room_id": 1}, {"room_id": 2}, {}))
-        assert "`1`" in result
-        assert "`2`" in result
+def test_fk_entity_name_with_markdown_chars_is_escaped():
+    room = _make_room(7, "Living*Room_[Main]")
+
+    async def _find(eid):
+        return room if eid == 7 else None
+
+    repos = {"room": types.SimpleNamespace(find_by_id=_find)}
+    result = _run(_resolve_fk_label("room_id", 7, repos))
+    safe_name = result.split('"')[1]
+    assert "\\*" in safe_name, "asterisk must be escaped"
+    assert "\\_" in safe_name, "underscore must be escaped"
+    assert "(7)" in result, "raw_id must be preserved unescaped"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_update_diff (plain functions)
+# ---------------------------------------------------------------------------
+
+def test_diff_fk_field_shows_entity_names():
+    repos = _make_test_repos()
+    result = _run(_build_update_diff("Device - foo", {"room_id": 3}, {"room_id": 5}, repos))
+    assert '"Living Room" (3)' in result
+    assert '"Kitchen" (5)' in result
+    assert "room_id" in result
+
+def test_diff_non_fk_field_shows_raw():
+    result = _run(_build_update_diff("Room - bar", {"name": "old"}, {"name": "new"}, {}))
+    assert "`old`" in result
+    assert "`new`" in result
+
+def test_diff_sensitive_field_is_masked():
+    result = _run(_build_update_diff("Device - x", {"password": "abc"}, {"password": "xyz"}, {}))
+    assert "`***`" in result
+    assert "abc" not in result
+    assert "xyz" not in result
+
+def test_diff_no_changes_returns_header_only():
+    result = _run(_build_update_diff("Room - foo", {"name": "same"}, {"name": "same"}, {}))
+    assert result == "Updated Room - foo"
+    assert "\n" not in result
+
+def test_diff_skip_fields_ignored():
+    result = _run(_build_update_diff(
+        "Room - foo",
+        {"name": "a", "updated_at": "2024-01-01"},
+        {"name": "a", "updated_at": "2024-06-01"},
+        {},
+    ))
+    assert result == "Updated Room - foo"
+
+def test_diff_fk_none_to_value():
+    room_b = _make_room(5, "Kitchen")
+
+    async def _find_room(eid):
+        return room_b if eid == 5 else None
+
+    repos = {"room": types.SimpleNamespace(find_by_id=_find_room)}
+    result = _run(_build_update_diff("Device - foo", {"room_id": None}, {"room_id": 5}, repos))
+    assert "_(none)_" in result
+    assert '"Kitchen" (5)' in result
+
+def test_diff_fk_fallback_when_repos_empty():
+    result = _run(_build_update_diff("Device - foo", {"room_id": 1}, {"room_id": 2}, {}))
+    assert "`1`" in result
+    assert "`2`" in result
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🔗 CRUD FK Diff Tests"
+TEST_SUITE = [
+    ("resolve FK: None value", test_fk_none_value_returns_none_marker),
+    ("resolve FK: unknown field", test_fk_unknown_field_returns_raw),
+    ("resolve FK: repo missing", test_fk_repo_not_in_repos_returns_raw),
+    ("resolve FK: entity not found", test_fk_entity_not_found_returns_raw),
+    ("resolve FK: entity found (name)", test_fk_entity_found_with_name),
+    ("resolve FK: entity found (display_name)", test_fk_entity_found_with_display_name),
+    ("resolve FK: repo raises", test_fk_repo_raises_returns_raw),
+    ("resolve FK: markdown chars escaped", test_fk_entity_name_with_markdown_chars_is_escaped),
+    ("diff FK field shows entity names", test_diff_fk_field_shows_entity_names),
+    ("diff non-FK field shows raw", test_diff_non_fk_field_shows_raw),
+    ("diff sensitive field masked", test_diff_sensitive_field_is_masked),
+    ("diff no changes returns header", test_diff_no_changes_returns_header_only),
+    ("diff skip fields ignored", test_diff_skip_fields_ignored),
+    ("diff FK None to value", test_diff_fk_none_to_value),
+    ("diff FK fallback when repos empty", test_diff_fk_fallback_when_repos_empty),
+]

--- a/custom_components/device_manager/tests/test_device.py
+++ b/custom_components/device_manager/tests/test_device.py
@@ -6,54 +6,19 @@ the same derived fields as the legacy Device class.
 
 import json
 from pathlib import Path
-import importlib.util
-import sys
-import types
 
-# Load modules by file path to avoid importing package __init__
-# (which requires homeassistant)
-base_dir = Path(__file__).resolve().parents[1]
+import helpers  # provided via sys.path by run_tests.py
 
-# Load case_convert utility
-case_convert_path = base_dir / 'utils' / 'case_convert.py'
-spec = importlib.util.spec_from_file_location('case_convert', str(case_convert_path))
-assert spec is not None and spec.loader is not None, "Cannot load case_convert"
-case_convert = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(case_convert)  # type: ignore[union-attr]
+# ---------------------------------------------------------------------------
+# Bootstrap: load DmDevice model via shared helper
+# ---------------------------------------------------------------------------
 
-# Create mock parent package modules for relative imports
-custom_components_module = types.ModuleType('custom_components')
-device_manager_module = types.ModuleType('device_manager')
-utils_module = types.ModuleType('utils')
-utils_module.case_convert = case_convert  # type: ignore[attr-defined]
-
-sys.modules['custom_components'] = custom_components_module
-sys.modules['custom_components.device_manager'] = device_manager_module
-sys.modules['custom_components.device_manager.utils'] = utils_module
-sys.modules['custom_components.device_manager.utils.case_convert'] = case_convert
-
-# Load base module
-base_path = base_dir / 'models' / 'base.py'
-spec = importlib.util.spec_from_file_location('base_module', str(base_path))
-assert spec is not None and spec.loader is not None, "Cannot load base model"
-base_module = importlib.util.module_from_spec(spec)
-base_module.__package__ = 'custom_components.device_manager.models'
-spec.loader.exec_module(base_module)  # type: ignore[union-attr]
-
-# Load device module
-device_path = base_dir / 'models' / 'device.py'
-spec = importlib.util.spec_from_file_location('device_module', str(device_path))
-assert spec is not None and spec.loader is not None, "Cannot load device model"
-device_module = importlib.util.module_from_spec(spec)
-device_module.__package__ = 'custom_components.device_manager.models'
-sys.modules['custom_components.device_manager.models.base'] = base_module
-spec.loader.exec_module(device_module)  # type: ignore[union-attr]
-
-DmDevice = device_module.DmDevice
-DeviceRoomRef = device_module.DeviceRoomRef
-DeviceFloorRef = device_module.DeviceFloorRef
-DeviceBuildingRef = device_module.DeviceBuildingRef
-DeviceLinkedRefs = device_module.DeviceLinkedRefs
+_m = helpers.load_device_model()
+DmDevice = _m.DmDevice
+DeviceRoomRef = _m.DeviceRoomRef
+DeviceFloorRef = _m.DeviceFloorRef
+DeviceBuildingRef = _m.DeviceBuildingRef
+DeviceLinkedRefs = _m.DeviceLinkedRefs
 
 FIXTURES = Path(__file__).parent / "fixtures" / "devices.json"
 
@@ -141,3 +106,13 @@ def test_compute_derived_fields_from_fixtures():
                 f"FQDN mismatch for {mac}: "
                 f"expected {expected_fqdn}, got {fqdn}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "📦 Device Model Tests (Legacy Fixtures)"
+TEST_SUITE = [
+    ("compute derived fields from fixtures", test_compute_derived_fields_from_fixtures),
+]

--- a/custom_components/device_manager/tests/test_dm_device_computed.py
+++ b/custom_components/device_manager/tests/test_dm_device_computed.py
@@ -4,60 +4,18 @@ These tests ensure that computed methods (mqtt_topic, hostname, fqdn)
 maintain their expected format and always return lowercase values.
 """
 
-from pathlib import Path
-import importlib.util
-import sys
-import types
+import helpers  # provided via sys.path by run_tests.py
 
-# Load modules by file path to avoid importing package __init__ (which requires homeassistant)
-base_dir = Path(__file__).resolve().parents[1]
+# ---------------------------------------------------------------------------
+# Bootstrap: load DmDevice model via shared helper
+# ---------------------------------------------------------------------------
 
-# Load case_convert utility
-case_convert_path = base_dir / 'utils' / 'case_convert.py'
-spec = importlib.util.spec_from_file_location('case_convert', str(case_convert_path))
-assert spec is not None and spec.loader is not None, "Cannot load case_convert"
-case_convert = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(case_convert)  # type: ignore[union-attr]
-
-# Load base module with injected dependencies
-base_path = base_dir / 'models' / 'base.py'
-spec = importlib.util.spec_from_file_location('base_module', str(base_path))
-assert spec is not None, "Cannot find spec for base_module"
-base_module = importlib.util.module_from_spec(spec)
-# Create a mock namespace for the relative imports
-# Create parent packages
-custom_components_module = types.ModuleType('custom_components')
-device_manager_module = types.ModuleType('device_manager')
-utils_module = types.ModuleType('utils')
-utils_module.case_convert = case_convert  # type: ignore[attr-defined]
-
-sys.modules['custom_components'] = custom_components_module
-sys.modules['custom_components.device_manager'] = device_manager_module
-sys.modules['custom_components.device_manager.utils'] = utils_module
-sys.modules['custom_components.device_manager.utils.case_convert'] = case_convert
-
-# Set __package__ so relative imports work
-base_module.__package__ = 'custom_components.device_manager.models'
-assert spec.loader is not None, "base_module spec has no loader"
-spec.loader.exec_module(base_module)  # type: ignore[union-attr]
-
-# Load device module
-device_path = base_dir / 'models' / 'device.py'
-spec = importlib.util.spec_from_file_location('device_module', str(device_path))
-assert spec is not None and spec.loader is not None, "Cannot load device_module"
-device_module = importlib.util.module_from_spec(spec)
-# Set __package__ so relative imports work
-device_module.__package__ = 'custom_components.device_manager.models'
-# Add base module to sys.modules so device can import it
-sys.modules['custom_components.device_manager.models.base'] = base_module
-spec.loader.exec_module(device_module)  # type: ignore[union-attr]
-
-# Import classes
-DmDevice = device_module.DmDevice
-DeviceRoomRef = device_module.DeviceRoomRef
-DeviceFloorRef = device_module.DeviceFloorRef
-DeviceBuildingRef = device_module.DeviceBuildingRef
-DeviceLinkedRefs = device_module.DeviceLinkedRefs
+_m = helpers.load_device_model()
+DmDevice = _m.DmDevice
+DeviceRoomRef = _m.DeviceRoomRef
+DeviceFloorRef = _m.DeviceFloorRef
+DeviceBuildingRef = _m.DeviceBuildingRef
+DeviceLinkedRefs = _m.DeviceLinkedRefs
 
 
 def create_test_device(
@@ -236,3 +194,24 @@ def test_to_camel_dict_full_includes_computed():
         assert hostname == hostname.lower(), f"hostname must be lowercase: {hostname}"
     if fqdn:
         assert fqdn == fqdn.lower(), f"fqdn must be lowercase: {fqdn}"
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🔧 DmDevice Computed Methods Tests"
+TEST_SUITE = [
+    ("mqtt_topic format & lowercase", test_mqtt_topic_format),
+    ("mqtt_topic None when missing building", test_mqtt_topic_returns_none_when_missing_building),
+    ("mqtt_topic structure (5 segments)", test_mqtt_topic_structure),
+    ("hostname format & lowercase", test_hostname_format),
+    ("hostname None when missing building", test_hostname_returns_none_when_missing_building),
+    ("fqdn format & lowercase", test_fqdn_format),
+    ("fqdn custom suffix", test_fqdn_custom_suffix),
+    ("display_name full hierarchy", test_display_name_full),
+    ("display_name fallback to MAC", test_display_name_fallback_to_mac),
+    ("link with full IP", test_link_with_full_ip),
+    ("link with numeric IP", test_link_with_numeric_ip),
+    ("to_camel_dict_full includes computed fields", test_to_camel_dict_full_includes_computed),
+]

--- a/custom_components/device_manager/tests/test_ha_floors.py
+++ b/custom_components/device_manager/tests/test_ha_floors.py
@@ -4,33 +4,17 @@ Validates floor ID generation and the controller's sync / rollback logic
 without requiring a live Home Assistant instance.
 """
 
-import importlib.util
 import sys
 import types
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 # ---------------------------------------------------------------------------
 # Minimal stub setup — load only the controller module under test
 # ---------------------------------------------------------------------------
 
-base_dir = Path(__file__).resolve().parents[1]
-
-# Stub aiohttp
-aiohttp_module = types.ModuleType("aiohttp")
-web_module = types.ModuleType("aiohttp.web")
-web_module.Request = object  # type: ignore[attr-defined]
-web_module.Response = object  # type: ignore[attr-defined]
-aiohttp_module.web = web_module  # type: ignore[attr-defined]
-sys.modules.setdefault("aiohttp", aiohttp_module)
-sys.modules.setdefault("aiohttp.web", web_module)
-
-# Stub homeassistant packages
-for mod_name in [
-    "homeassistant",
-    "homeassistant.components",
-    "homeassistant.components.http",
-]:
-    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
+helpers.stub_ha_modules()
+helpers.stub_aiohttp()
 
 
 class _FakeHAView:
@@ -73,14 +57,11 @@ sys.modules[
 ] = base_ctrl_stub
 
 # Now load the actual module under test
-ctrl_path = base_dir / "controllers" / "ha_floors_controller.py"
-spec = importlib.util.spec_from_file_location(
-    "ha_floors_controller", str(ctrl_path)
+ctrl_module = helpers.load_module(
+    "controllers/ha_floors_controller.py",
+    package="custom_components.device_manager.controllers",
+    module_name="ha_floors_controller",
 )
-assert spec is not None and spec.loader is not None
-ctrl_module = importlib.util.module_from_spec(spec)
-ctrl_module.__package__ = "custom_components.device_manager.controllers"
-spec.loader.exec_module(ctrl_module)  # type: ignore[union-attr]
 
 HaFloorsSyncAPIView = ctrl_module.HaFloorsSyncAPIView
 
@@ -308,3 +289,23 @@ def test_level_resets_per_building():
     # Erwan floors — level resets to 0
     assert synced[2] == {"name": "Erwan - Lvl0", "level": 0}
     assert synced[3] == {"name": "Erwan - Lvl1", "level": 1}
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🏢 HA Floors Controller Tests"
+TEST_SUITE = [
+    ("registry create auto-generates floor_id", test_registry_create_auto_generates_id),
+    ("registry get_floor_by_name found", test_registry_get_floor_by_name_found),
+    ("registry get_floor_by_name missing", test_registry_get_floor_by_name_missing),
+    ("rollback deletes created floors", test_rollback_deletes_created_floors),
+    ("rollback restores updated floors", test_rollback_restores_updated_floors),
+    ("rollback is reversed order", test_rollback_is_reversed_order),
+    ("rollback skips update without original", test_rollback_skips_update_without_original),
+    ("rollback tolerates registry error", test_rollback_tolerates_registry_error),
+    ("create entry floor_id is accessible", test_create_entry_floor_id_is_accessible),
+    ("ha name per building is unique", test_ha_name_per_building_is_unique),
+    ("level resets per building", test_level_resets_per_building),
+]

--- a/custom_components/device_manager/tests/test_ha_groups.py
+++ b/custom_components/device_manager/tests/test_ha_groups.py
@@ -4,37 +4,17 @@ Validates entity ID generation, slugification, domain mapping and group naming
 without requiring a live Home Assistant instance.
 """
 
-import importlib.util
 import sys
 import types
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 # ---------------------------------------------------------------------------
 # Minimal stub setup — load only the controller module under test
 # ---------------------------------------------------------------------------
 
-base_dir = Path(__file__).resolve().parents[1]
-
-# The controller only imports `aiohttp.web` and `.base` at top-level.
-# We mock them so the module loads without a real HA environment.
-
-# Stub aiohttp
-aiohttp_module = types.ModuleType("aiohttp")
-web_module = types.ModuleType("aiohttp.web")
-web_module.Request = object  # type: ignore[attr-defined]
-web_module.Response = object  # type: ignore[attr-defined]
-aiohttp_module.web = web_module  # type: ignore[attr-defined]
-sys.modules.setdefault("aiohttp", aiohttp_module)
-sys.modules.setdefault("aiohttp.web", web_module)
-
-# Stub homeassistant packages
-for mod_name in [
-    "homeassistant",
-    "homeassistant.components",
-    "homeassistant.components.http",
-]:
-    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
-
+helpers.stub_ha_modules()
+helpers.stub_aiohttp()
 
 class _FakeHAView:
     requires_auth = True
@@ -73,14 +53,11 @@ sys.modules[
 ] = base_ctrl_stub
 
 # Now load the actual module under test
-ctrl_path = base_dir / "controllers" / "ha_groups_controller.py"
-spec = importlib.util.spec_from_file_location(
-    "ha_groups_controller", str(ctrl_path)
+ctrl_module = helpers.load_module(
+    "controllers/ha_groups_controller.py",
+    package="custom_components.device_manager.controllers",
+    module_name="ha_groups_controller",
 )
-assert spec is not None and spec.loader is not None
-ctrl_module = importlib.util.module_from_spec(spec)
-ctrl_module.__package__ = "custom_components.device_manager.controllers"
-spec.loader.exec_module(ctrl_module)  # type: ignore[union-attr]
 
 # Grab helpers
 _slugify = ctrl_module._slugify
@@ -185,3 +162,37 @@ def test_floor_group_has_building_prefix():
 def test_building_group_has_building_prefix():
     obj = _building_group_object_id("myHome", "shutters")
     assert obj.startswith("my")
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🏠 HA Groups Controller Tests"
+TEST_SUITE = [
+    ("slugify basic", test_slugify_basic),
+    ("slugify spaces", test_slugify_spaces),
+    ("slugify special chars", test_slugify_special_chars),
+    ("slugify multiple separators", test_slugify_multiple_separators),
+    ("ha_domain light", test_ha_domain_light),
+    ("ha_domain shutter → cover", test_ha_domain_shutter),
+    ("ha_domain heater → climate", test_ha_domain_heater),
+    ("ha_domain tv → media_player", test_ha_domain_tv),
+    ("ha_domain button → binary_sensor", test_ha_domain_button),
+    ("ha_domain energy → sensor", test_ha_domain_energy),
+    ("ha_domain unknown → switch", test_ha_domain_unknown_defaults_to_switch),
+    ("ha_domain case insensitive", test_ha_domain_case_insensitive),
+    ("plural light", test_plural_light),
+    ("plural shutter", test_plural_shutter),
+    ("plural unknown appends s", test_plural_unknown_appends_s),
+    ("device entity_id standard", test_device_entity_id_standard),
+    ("device entity_id matches hostname pattern", test_device_entity_id_matches_hostname_pattern),
+    ("device entity_id uppercase building", test_device_entity_id_uppercase_building),
+    ("device entity_id empty position omitted", test_device_entity_id_empty_position_omitted),
+    ("room group entity_id", test_room_group_entity_id),
+    ("floor group entity_id", test_floor_group_entity_id),
+    ("building group entity_id", test_building_group_entity_id),
+    ("room group special chars", test_room_group_special_chars),
+    ("floor group has building prefix", test_floor_group_has_building_prefix),
+    ("building group has building prefix", test_building_group_has_building_prefix),
+]

--- a/custom_components/device_manager/tests/test_ha_rooms.py
+++ b/custom_components/device_manager/tests/test_ha_rooms.py
@@ -4,33 +4,17 @@ Validates the controller's sync / rollback logic without requiring a live
 Home Assistant instance.
 """
 
-import importlib.util
 import sys
 import types
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 # ---------------------------------------------------------------------------
 # Minimal stub setup — load only the controller module under test
 # ---------------------------------------------------------------------------
 
-base_dir = Path(__file__).resolve().parents[1]
-
-# Stub aiohttp
-aiohttp_module = types.ModuleType("aiohttp")
-web_module = types.ModuleType("aiohttp.web")
-web_module.Request = object  # type: ignore[attr-defined]
-web_module.Response = object  # type: ignore[attr-defined]
-aiohttp_module.web = web_module  # type: ignore[attr-defined]
-sys.modules.setdefault("aiohttp", aiohttp_module)
-sys.modules.setdefault("aiohttp.web", web_module)
-
-# Stub homeassistant packages
-for mod_name in [
-    "homeassistant",
-    "homeassistant.components",
-    "homeassistant.components.http",
-]:
-    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
+helpers.stub_ha_modules()
+helpers.stub_aiohttp()
 
 
 class _FakeHAView:
@@ -73,14 +57,11 @@ sys.modules[
 ] = base_ctrl_stub
 
 # Now load the actual module under test
-ctrl_path = base_dir / "controllers" / "ha_rooms_controller.py"
-spec = importlib.util.spec_from_file_location(
-    "ha_rooms_controller", str(ctrl_path)
+ctrl_module = helpers.load_module(
+    "controllers/ha_rooms_controller.py",
+    package="custom_components.device_manager.controllers",
+    module_name="ha_rooms_controller",
 )
-assert spec is not None and spec.loader is not None
-ctrl_module = importlib.util.module_from_spec(spec)
-ctrl_module.__package__ = "custom_components.device_manager.controllers"
-spec.loader.exec_module(ctrl_module)  # type: ignore[union-attr]
 
 HaRoomsSyncAPIView = ctrl_module.HaRoomsSyncAPIView
 _compute_area_id = ctrl_module._compute_area_id
@@ -355,3 +336,29 @@ def test_rollback_multiple_rooms_reversed():
         f"delete:{e1.id}",
         f"delete:{e0.id}",
     ]
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🚪 HA Rooms Controller Tests"
+TEST_SUITE = [
+    ("registry create auto-generates area id", test_registry_create_auto_generates_id),
+    ("registry create with floor_id", test_registry_create_with_floor_id),
+    ("registry get_area_by_name missing", test_registry_get_area_by_name_missing),
+    ("rollback deletes created areas", test_rollback_deletes_created_areas),
+    ("rollback restores updated areas", test_rollback_restores_updated_areas),
+    ("rollback is reversed order", test_rollback_is_reversed_order),
+    ("rollback skips update without original", test_rollback_skips_update_without_original),
+    ("rollback multiple rooms reversed", test_rollback_multiple_rooms_reversed),
+    ("compute_area_id basic", test_compute_area_id_basic),
+    ("slugify fallback ascii", test_slugify_fallback_ascii),
+    ("compute_area_id special chars", test_compute_area_id_special_chars),
+    ("registry create then update name keeps id", test_registry_create_then_update_name_keeps_id),
+    ("compute_area_id matches registry create id", test_compute_area_id_matches_registry_create_id),
+    ("registry get_area by id found", test_registry_get_area_by_id_found),
+    ("registry get_area missing", test_registry_get_area_missing),
+    ("duplicate name detection", test_duplicate_name_detection),
+    ("unique name not marked duplicate", test_unique_name_not_marked_duplicate),
+]

--- a/custom_components/device_manager/tests/test_identifier_validation.py
+++ b/custom_components/device_manager/tests/test_identifier_validation.py
@@ -10,24 +10,15 @@ Covers all accepted identifier formats:
 
 import sys
 import types
-import importlib.util
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 
 def _load_device_controller():
     """Load device_controller.py with all HA/aiohttp dependencies mocked."""
-    base_dir = Path(__file__).resolve().parents[1]
+    helpers.stub_aiohttp()
+    helpers.stub_ha_modules()
 
-    # Mock aiohttp
-    aiohttp_mod = types.ModuleType("aiohttp")
-    web_mod = types.ModuleType("aiohttp.web")
-    web_mod.Request = object  # type: ignore[attr-defined]
-    web_mod.Response = object  # type: ignore[attr-defined]
-    aiohttp_mod.web = web_mod  # type: ignore[attr-defined]
-    sys.modules.setdefault("aiohttp", aiohttp_mod)
-    sys.modules.setdefault("aiohttp.web", web_mod)
-
-    # Ensure package namespace exists
     for pkg in (
         "custom_components",
         "custom_components.device_manager",
@@ -64,16 +55,11 @@ def _load_device_controller():
     case_convert_mod.to_snake_case_dict = lambda d: d  # type: ignore[attr-defined]
     sys.modules["custom_components.device_manager.utils.case_convert"] = case_convert_mod
 
-    controller_path = base_dir / "controllers" / "device_controller.py"
-    spec = importlib.util.spec_from_file_location(
-        "custom_components.device_manager.controllers.device_controller",
-        str(controller_path),
+    return helpers.load_module(
+        "controllers/device_controller.py",
+        package="custom_components.device_manager.controllers",
+        module_name="custom_components.device_manager.controllers.device_controller",
     )
-    assert spec is not None and spec.loader is not None, "Cannot load device_controller"
-    mod = importlib.util.module_from_spec(spec)
-    mod.__package__ = "custom_components.device_manager.controllers"
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    return mod
 
 
 _ctrl = _load_device_controller()
@@ -150,3 +136,25 @@ def test_short_eui64_rejected():
 
 def test_eui64_wrong_prefix_rejected():
     assert not _is_valid_identifier("00124b0025156aca")         # 16 hex but no 0x prefix
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "🔒 Identifier Validation Tests"
+TEST_SUITE = [
+    ("MAC colon uppercase", test_mac_colon_uppercase),
+    ("MAC colon lowercase", test_mac_colon_lowercase),
+    ("MAC hyphen", test_mac_hyphen),
+    ("MAC compact", test_mac_compact),
+    ("EUI-64 colon", test_eui64_colon),
+    ("Zigbee EUI-64 (0x...)", test_zigbee_eui64_hex_prefix),
+    ("empty string rejected", test_empty_string_rejected),
+    ("plain text rejected", test_plain_text_rejected),
+    ("non-hex chars rejected", test_non_hex_chars_rejected),
+    ("IP address rejected", test_ip_address_rejected),
+    ("short MAC rejected", test_short_mac_rejected),
+    ("short EUI-64 rejected", test_short_eui64_rejected),
+    ("EUI-64 without 0x rejected", test_eui64_wrong_prefix_rejected),
+]

--- a/custom_components/device_manager/tests/test_import.py
+++ b/custom_components/device_manager/tests/test_import.py
@@ -1,64 +1,48 @@
 """Tests for CSV import functionality."""
 
 import asyncio
-from pathlib import Path
-import tempfile
-import importlib.util
 import sys
 import types
+from pathlib import Path
+import tempfile
 
-# Load modules by file path to avoid importing package __init__
-# (which requires homeassistant)
-base_dir = Path(__file__).resolve().parents[1]
+import helpers  # provided via sys.path by run_tests.py
 
-# Load database_manager
-db_manager_path = base_dir / 'services' / 'database_manager.py'
-spec = importlib.util.spec_from_file_location('database_manager', str(db_manager_path))
-assert spec is not None and spec.loader is not None, "Cannot load database_manager"
-database_manager_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(database_manager_module)  # type: ignore[union-attr]
+# ---------------------------------------------------------------------------
+# Bootstrap: load services and repositories without importing the full HA package
+# ---------------------------------------------------------------------------
+
+database_manager_module = helpers.load_module("services/database_manager.py")
 DatabaseManager = database_manager_module.DatabaseManager  # type: ignore[attr-defined]
 
-# Load csv_import_service
-csv_import_path = base_dir / 'services' / 'csv_import_service.py'
-spec = importlib.util.spec_from_file_location('csv_import_service', str(csv_import_path))
-assert spec is not None and spec.loader is not None, "Cannot load csv_import_service"
-csv_import_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(csv_import_module)  # type: ignore[union-attr]
+csv_import_module = helpers.load_module("services/csv_import_service.py")
 CSVImportService = csv_import_module.CSVImportService  # type: ignore[attr-defined]
 
-# Load repositories
-base_repo_path = base_dir / 'repositories' / 'base.py'
-spec = importlib.util.spec_from_file_location('base_repository', str(base_repo_path))
-assert spec is not None, "Cannot find spec for base_repository"
-base_repo_module = importlib.util.module_from_spec(spec)
+# Inject package namespace for relative imports in repositories
+_cm = types.ModuleType("custom_components")
+_dm = types.ModuleType("custom_components.device_manager")
+_svc = types.ModuleType("custom_components.device_manager.services")
+_svc.database_manager = database_manager_module  # type: ignore[attr-defined]
 
-# Create mock modules for relative imports in repositories
-custom_components_module = types.ModuleType('custom_components')
-device_manager_module = types.ModuleType('device_manager')
-services_module = types.ModuleType('services')
-services_module.database_manager = database_manager_module  # type: ignore[attr-defined]
+sys.modules["custom_components"] = _cm
+sys.modules["custom_components.device_manager"] = _dm
+sys.modules["custom_components.device_manager.services"] = _svc
+sys.modules["custom_components.device_manager.services.database_manager"] = database_manager_module
 
-sys.modules['custom_components'] = custom_components_module
-sys.modules['custom_components.device_manager'] = device_manager_module
-sys.modules['custom_components.device_manager.services'] = services_module
-sys.modules['custom_components.device_manager.services.database_manager'] = database_manager_module
-
-base_repo_module.__package__ = 'custom_components.device_manager.repositories'
-assert spec is not None and spec.loader is not None, "Cannot load base_repository"
-spec.loader.exec_module(base_repo_module)  # type: ignore[union-attr]
+base_repo_module = helpers.load_module(
+    "repositories/base.py",
+    package="custom_components.device_manager.repositories",
+)
 
 
 # Load individual repository modules
 def load_repository(repo_name: str):
     """Load a repository module."""
-    repo_path = base_dir / 'repositories' / f'{repo_name}.py'
-    spec = importlib.util.spec_from_file_location(repo_name, str(repo_path))
-    assert spec is not None and spec.loader is not None, f"Cannot load {repo_name}"
-    repo_module = importlib.util.module_from_spec(spec)
-    repo_module.__package__ = 'custom_components.device_manager.repositories'
-    sys.modules['custom_components.device_manager.repositories.base'] = base_repo_module
-    spec.loader.exec_module(repo_module)  # type: ignore[union-attr]
+    sys.modules["custom_components.device_manager.repositories.base"] = base_repo_module
+    return helpers.load_module(
+        f"repositories/{repo_name}.py",
+        package="custom_components.device_manager.repositories",
+    )
 
 
 SAMPLE_CSV = Path(__file__).resolve().parents[2] / "samples" / "Electrique - Domotique.csv"
@@ -108,3 +92,13 @@ def test_csv_import_to_db():
             )
 
     asyncio.run(coro())
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "📥 CSV Import Tests"
+TEST_SUITE = [
+    ("csv import to database", test_csv_import_to_db),
+]

--- a/custom_components/device_manager/tests/test_init_unload.py
+++ b/custom_components/device_manager/tests/test_init_unload.py
@@ -179,3 +179,25 @@ class TestAsyncUnloadEntry(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+def _make_unload_test(method_name: str):
+    """Wrap a TestAsyncUnloadEntry method so setUp() is called first."""
+    def _run():
+        inst = TestAsyncUnloadEntry()
+        inst.setUp()
+        getattr(inst, method_name)()
+    return _run
+
+
+SUITE_LABEL = "🔌 Integration Unload Tests"
+TEST_SUITE = [
+    ("async_remove_panel called on unload", _make_unload_test("test_async_remove_panel_called_on_unload")),
+    ("db closed on unload", _make_unload_test("test_db_closed_on_unload")),
+    ("hass.data cleared on unload", _make_unload_test("test_hass_data_cleared_on_unload")),
+    ("unload returns True", _make_unload_test("test_unload_returns_true")),
+]

--- a/custom_components/device_manager/tests/test_mosquitto_config.py
+++ b/custom_components/device_manager/tests/test_mosquitto_config.py
@@ -5,29 +5,19 @@ production controller so they exercise the real code path instead of
 a local copy.
 """
 
-import importlib.util
 import io
 import sys
 import types
 import zipfile
-from pathlib import Path
+
+import helpers  # provided via sys.path by run_tests.py
 
 # ---------------------------------------------------------------------------
 # Bootstrap: load maintenance_controller without importing the full HA package
 # ---------------------------------------------------------------------------
 
-base_dir = Path(__file__).resolve().parents[1]
-
-_ha_http = types.ModuleType("homeassistant.components.http")
-_ha_http.HomeAssistantView = object  # type: ignore[attr-defined]
-for _mod_name, _mod in [
-    ("homeassistant", types.ModuleType("homeassistant")),
-    ("homeassistant.components", types.ModuleType("homeassistant.components")),
-    ("homeassistant.components.http", _ha_http),
-    ("aiohttp", types.ModuleType("aiohttp")),
-    ("aiohttp.web", types.ModuleType("aiohttp.web")),
-]:
-    sys.modules.setdefault(_mod_name, _mod)  # type: ignore[arg-type]
+helpers.stub_ha_modules()
+helpers.stub_aiohttp()
 
 _base_stub = types.ModuleType("custom_components.device_manager.controllers.base")
 _base_stub.BaseView = object  # type: ignore[attr-defined]
@@ -52,12 +42,11 @@ for _mod_name, _mod in [
 ]:
     sys.modules.setdefault(_mod_name, _mod)  # type: ignore[arg-type]
 
-_ctrl_path = base_dir / "controllers" / "maintenance_controller.py"
-_spec = importlib.util.spec_from_file_location("maintenance_controller", str(_ctrl_path))
-assert _spec and _spec.loader
-_ctrl_module = importlib.util.module_from_spec(_spec)
-_ctrl_module.__package__ = "custom_components.device_manager.controllers"
-_spec.loader.exec_module(_ctrl_module)  # type: ignore[union-attr]
+_ctrl_module = helpers.load_module(
+    "controllers/maintenance_controller.py",
+    package="custom_components.device_manager.controllers",
+    module_name="maintenance_controller",
+)
 
 # The real production function under test
 generate_mosquitto_files = _ctrl_module.generate_mosquitto_files  # type: ignore[attr-defined]
@@ -170,3 +159,23 @@ def test_room_with_none_password_skipped():
     assert "user_ok:pass_ok" in passwd
     assert "user_bad" not in passwd
     assert "room_bad" not in acl
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "📡 Mosquitto Config Generation Tests"
+TEST_SUITE = [
+    ("passwd contains room credentials", test_passwd_contains_room_credentials),
+    ("passwd contains admin", test_passwd_contains_admin),
+    ("acl room topic format", test_acl_room_topic_format),
+    ("acl admin full access", test_acl_admin_full_access),
+    ("room without credentials skipped", test_room_without_credentials_skipped),
+    ("mosquitto.conf references correct paths", test_mosquitto_conf_references_correct_paths),
+    ("zip contains three files", test_zip_contains_three_files),
+    ("mqtt prefix leading slash stripped", test_mqtt_prefix_leading_slash_stripped),
+    ("empty hierarchy only admin", test_empty_hierarchy_only_admin),
+    ("no admin password skips admin entry", test_no_admin_password_skips_admin_entry),
+    ("room with None password skipped", test_room_with_none_password_skipped),
+]

--- a/custom_components/device_manager/tests/test_network_scanner.py
+++ b/custom_components/device_manager/tests/test_network_scanner.py
@@ -5,39 +5,19 @@ returning an empty dict, so callers can handle errors explicitly.
 """
 
 import asyncio
-import importlib.util
-import re
 import subprocess
 import sys
 import types
-from contextlib import contextmanager
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import helpers  # provided via sys.path by run_tests.py
 
-@contextmanager
-def assert_raises(expected_exc, match: str = ""):
-    """Stdlib-only replacement for pytest.raises with optional message match."""
-    try:
-        yield
-    except expected_exc as exc:  # type: ignore[misc]
-        if match and not re.search(match, str(exc)):
-            raise AssertionError(
-                f"{expected_exc.__name__} raised but message {str(exc)!r} "
-                f"did not match pattern {match!r}"
-            ) from exc
-        return
-    except Exception as exc:
-        raise AssertionError(
-            f"Expected {expected_exc.__name__}, got {type(exc).__name__}: {exc}"
-        ) from exc
-    raise AssertionError(f"{expected_exc.__name__} was not raised")
+# Re-export assert_raises from helpers so existing test code using it works
+assert_raises = helpers.assert_raises
 
 # ---------------------------------------------------------------------------
 # Bootstrap: load scanner module without importing the full HA package
 # ---------------------------------------------------------------------------
-
-base_dir = Path(__file__).resolve().parents[1]
 
 # Stub out all transitive dependencies
 _yaml_stub = types.ModuleType("yaml")
@@ -48,11 +28,10 @@ class _YAMLError(Exception):
 
 _yaml_stub.YAMLError = _YAMLError  # type: ignore[attr-defined]
 
+helpers.stub_ha_modules()
+
 for _mod_name, _mod in [
     ("yaml", _yaml_stub),
-    ("homeassistant", types.ModuleType("homeassistant")),
-    ("homeassistant.components", types.ModuleType("homeassistant.components")),
-    ("homeassistant.components.http", types.ModuleType("homeassistant.components.http")),
 ]:
     sys.modules.setdefault(_mod_name, _mod)
 
@@ -80,12 +59,11 @@ for _k, _v in [
     sys.modules.setdefault(_k, _v)
 
 # Load scanner module
-_scanner_path = base_dir / "provisioning" / "core" / "scanner.py"
-_spec = importlib.util.spec_from_file_location("scanner_module", str(_scanner_path))
-assert _spec and _spec.loader
-_scanner_module = importlib.util.module_from_spec(_spec)
-_scanner_module.__package__ = "custom_components.device_manager.provisioning.core"
-_spec.loader.exec_module(_scanner_module)  # type: ignore[union-attr]
+_scanner_module = helpers.load_module(
+    "provisioning/core/scanner.py",
+    package="custom_components.device_manager.provisioning.core",
+    module_name="scanner_module",
+)
 
 NetworkScanner = _scanner_module.NetworkScanner  # type: ignore[attr-defined]
 NetworkScanError = _scanner_module.NetworkScanError  # type: ignore[attr-defined]
@@ -228,3 +206,21 @@ def test_update_device_ips_with_empty_scan_proceeds():
 
     assert result["errors"] == 0
     assert result["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test suite registration
+# ---------------------------------------------------------------------------
+
+SUITE_LABEL = "📡 Network Scanner Error Propagation Tests"
+TEST_SUITE = [
+    ("missing script config raises", test_missing_scan_script_raises),
+    ("timeout raises NetworkScanError", test_timeout_raises),
+    ("subprocess exception raises", test_subprocess_exception_raises),
+    ("nonzero exit code raises", test_nonzero_exit_raises),
+    ("invalid YAML output raises", test_invalid_yaml_raises),
+    ("non-dict output raises", test_non_dict_output_raises),
+    ("successful scan returns dict", test_successful_scan_returns_dict),
+    ("update_device_ips without scan returns error", test_update_device_ips_without_scan_returns_error),
+    ("update_device_ips with empty scan proceeds", test_update_device_ips_with_empty_scan_proceeds),
+]


### PR DESCRIPTION
## Summary

Harmonizes the unit test structure across all 11 test modules by introducing a shared `helpers.py` module and a consistent `TEST_SUITE` pattern. Simplifies the test runner (`run_tests.py`) from 420 to 84 lines.

## Related Issue

Closes #39

## Changes

- `run_tests.py`: rewritten to auto-discover `SUITE_LABEL` / `TEST_SUITE` from each module via a `_TEST_MODULES` list — no more manual re-exports
- `tests/helpers.py` (**new**): shared bootstrap utilities — `stub_ha_modules()`, `stub_aiohttp()`, `load_module()`, `assert_raises()`, `load_device_model()` — lazy, idempotent, stdlib-only
- `tests/test_device.py` + `tests/test_dm_device_computed.py`: eliminated ~30-line duplicated DmDevice bootstrap via `helpers.load_device_model()`
- `tests/test_crud_fk_diff.py`: converted `TestResolveFkLabel` / `TestBuildUpdateDiffFk` classes to plain functions (15 tests)
- `tests/test_init_unload.py`: kept `unittest.TestCase` (setUp needed), bridged via `_make_unload_test()` wrapper
- All other test files: replaced inline `sys.modules.setdefault(...)` blocks with `helpers.stub_ha_modules()` / `helpers.stub_aiohttp()` / `helpers.load_module()`, added `SUITE_LABEL` + `TEST_SUITE`

## Testing

- All **119 tests pass** (`python3 custom_components/device_manager/run_tests.py`)
- `mypy --ignore-missing-imports`: **no issues found** in 13 source files
- No new dependencies (stdlib-only)

## Notes

No breaking changes. The `TEST_SUITE` pattern is a list of `(label: str, func: callable)` pairs — straightforward to extend when adding new tests.
